### PR TITLE
Update gosql.ps1

### DIFF
--- a/gosql.ps1
+++ b/gosql.ps1
@@ -14,7 +14,7 @@ $i
 $i=1
 foreach($service in $svc)
 {
-if (($svc[$i].name -eq "MSSQLSERVER" -or
+if ($svc[$i].name -eq "MSSQLSERVER" -or
     $svc[$i].name -eq "SQLSERVERAGENT" -or
     $svc[$i].name -eq "MSSQLFDLauncher" -or
     $svc[$i].name -eq "SQLServerReportingServices" -or


### PR DESCRIPTION
The if cycle at line 17 "if (($svc[$i].name -eq "MSSQLSERVER" -or" starts with a double open parenthesis but is only closed once.